### PR TITLE
Add support for "in" predicate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ fun availableOnNetflix(available: Boolean?): Specifications<TvShow>? = available
     TvShow::availableOnNetflix.equal(it)
 }
 
+fun hasReleaseDateIn(releaseDates: List<String>?): Specifications<TvShow>? = releaseDates?.let {
+    TvShow::releaseDate.`in`(releaseDates)
+}
+
 fun hasKeywordIn(keywords: List<String>?): Specifications<TvShow>? = keywords?.let {
-    or(keywords.map { hasKeyword(it) })
+    or(keywords.map(::hasKeyword))
 }
 
 fun hasKeyword(keyword: String?): Specifications<TvShow>? = keyword?.let {
@@ -119,7 +123,8 @@ Or they can be combined with a service-layer query DTO and mapping extension fun
     data class TvShowQuery(
             val name: String? = null,
             val availableOnNetflix: Boolean? = null,
-            val keywords: List<String> = listOf()
+            val keywords: List<String> = listOf(),
+            val releaseDates: List<String> = listOf()
     )
 
     /**
@@ -129,7 +134,8 @@ Or they can be combined with a service-layer query DTO and mapping extension fun
     fun TvShowQuery.toSpecification(): Specifications<TvShow> = and(
             hasName(name),
             availableOnNetflix(availableOnNetflix),
-            hasKeywordIn(keywords)
+            hasKeywordIn(keywords),
+            hasReleaseDateIn(releaseDates)
     )
 ```
 

--- a/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
+++ b/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
@@ -23,8 +23,9 @@ private fun <T, R> KProperty1<T, R?>.spec(makePredicate: CriteriaBuilder.(path: 
 fun <T, R> KProperty1<T, R?>.equal(x: R): Specifications<T> = spec { equal(it, x) }
 fun <T, R> KProperty1<T, R?>.notEqual(x: R): Specifications<T> = spec { notEqual(it, x) }
 
-fun <T, R: Any> KProperty1<T, R?>.`in`(x: Collection<R>): Specifications<T> = if (x.isNotEmpty()) spec {
-    `in`(it).apply { x.forEach { this.value(it) } }
+// Ignores empty collection otherwise an empty 'in' predicate will be generated which will never match any results
+fun <T, R: Any> KProperty1<T, R?>.`in`(values: Collection<R>): Specifications<T> = if (values.isNotEmpty()) spec { path ->
+    `in`(path).apply { values.forEach { this.value(it) } }
 } else Specifications.where<T>(null)
 
 // Comparison

--- a/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
+++ b/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
@@ -23,6 +23,10 @@ private fun <T, R> KProperty1<T, R?>.spec(makePredicate: CriteriaBuilder.(path: 
 fun <T, R> KProperty1<T, R?>.equal(x: R): Specifications<T> = spec { equal(it, x) }
 fun <T, R> KProperty1<T, R?>.notEqual(x: R): Specifications<T> = spec { notEqual(it, x) }
 
+fun <T, R: Any> KProperty1<T, R?>.`in`(x: Collection<R>): Specifications<T> = if (x.isNotEmpty()) spec {
+    `in`(it).apply { x.forEach { this.value(it) } }
+} else Specifications.where<T>(null)
+
 // Comparison
 fun <T> KProperty1<T, Number?>.le(x: Number) = spec { le(it, x) }
 fun <T> KProperty1<T, Number?>.lt(x: Number) = spec { lt(it, x) }

--- a/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
+++ b/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
@@ -66,7 +66,8 @@ open class JPASpecificationDSLTest {
     data class TvShowQuery(
             val name: String? = null,
             val availableOnNetflix: Boolean? = null,
-            val keywords: List<String> = listOf()
+            val keywords: List<String> = listOf(),
+            val releaseDates: List<String> = listOf()
     )
 
     /**
@@ -76,7 +77,8 @@ open class JPASpecificationDSLTest {
     fun TvShowQuery.toSpecification(): Specifications<TvShow> = and(
             hasName(name),
             availableOnNetflix(availableOnNetflix),
-            hasKeywordIn(keywords)
+            hasKeywordIn(keywords),
+            hasReleaseDateIn(releaseDates)
     )
 
     /**
@@ -102,6 +104,12 @@ open class JPASpecificationDSLTest {
     fun `Get tv shows by id notEqual`() {
         val shows = tvShowRepo.findAll(TvShow::name.notEqual(theWalkingDead.name))
         assertThat(shows, containsInAnyOrder(betterCallSaul, hemlockGrove))
+    }
+
+    @Test
+    fun `Get tv show by id in`() {
+        val shows = tvShowRepo.findAll(TvShow::id.`in`(setOf(hemlockGrove.id, theWalkingDead.id)))
+        assertThat(shows, containsInAnyOrder(hemlockGrove, theWalkingDead))
     }
 
     @Test

--- a/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
+++ b/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
@@ -280,7 +280,7 @@ open class JPASpecificationDSLTest {
     fun `Find tv shows by multiple query DTOs`() {
         val queries = listOf(
                 TvShowQuery(availableOnNetflix = false, keywords = listOf("Jimmy")),
-                TvShowQuery(availableOnNetflix = true, keywords = listOf("killer", "monster"))
+                TvShowQuery(availableOnNetflix = true, keywords = listOf("killer", "monster"), releaseDates = listOf("2010", "2013"))
         )
         val shows = tvShowRepo.findAll(queries.toSpecification())
         assertThat(shows, containsInAnyOrder(betterCallSaul, hemlockGrove))

--- a/src/test/kotlin/au/com/console/jpaspecificationdsl/TvShowRepository.kt
+++ b/src/test/kotlin/au/com/console/jpaspecificationdsl/TvShowRepository.kt
@@ -44,14 +44,14 @@ fun availableOnNetflix(available: Boolean?): Specifications<TvShow>? = available
     TvShow::availableOnNetflix.equal(it)
 }
 
+fun hasReleaseDateIn(releaseDates: List<String>?): Specifications<TvShow>? = releaseDates?.let {
+    TvShow::releaseDate.`in`(releaseDates)
+}
+
 fun hasKeywordIn(keywords: List<String>?): Specifications<TvShow>? = keywords?.let {
-    or(keywords.map { hasKeyword(it) })
+    or(keywords.map(::hasKeyword))
 }
 
 fun hasKeyword(keyword: String?): Specifications<TvShow>? = keyword?.let {
     TvShow::synopsis.like("%$keyword%")
 }
-
-
-
-


### PR DESCRIPTION
- Handles empty collections by returning an empty specification (otherwise no results will ever match)
- Added example to README (`hasReleaseDateIn()`)