### PR TITLE
Configure OSSRH publishing to Maven Central

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,15 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -24,10 +25,10 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Gradle
-        run: gradle build
+        run: ./gradlew build
 
       - name: Publish to Sonatype OSSRH
-        run: gradle publish
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+
+# This workflow will build a package using Gradle and then publish it to Sonatype OSSRH
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Build with Gradle
+        run: gradle build
+
+      - name: Publish to Sonatype OSSRH
+        run: gradle publish
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Hat tip to [Mike Buhot](https://github.com/mbuhot) for the initial implementatio
 
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile("au.com.console:kotlin-jpa-specification-dsl:2.0.0")
+    compile("au.com.console:kotlin-jpa-specification-dsl:2.1.0")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'au.com.console'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'nebula.release' version '14.0.2'
     id 'nebula.kotlin' version '1.3.72'
     id 'nebula.maven-publish' version '14.1.1'
-    id 'com.jfrog.bintray' version '1.8.4'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
 group 'au.com.console'
@@ -35,28 +35,11 @@ test {
     }
 }
 
-tasks.bintrayUpload.dependsOn tasks.check
-
-gradle.taskGraph.whenReady { graph ->
-    tasks.bintrayUpload.onlyIf {
-        graph.hasTask(':final') || graph.hasTask(':candidate')
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    publications = ['nebula']
-    // allow republshing in case bintray fails to upload properly
-    override = true
-    pkg {
-        repo = 'kotlin'
-        userOrg = 'consoleau'
-        name = 'kotlin-jpa-specification-dsl'
-        licenses = ['Apache-2.0']
-        labels = ['kotlin','spring']
-        websiteUrl = "https://github.com/consoleau/${project.name}"
-        issueTrackerUrl = "https://github.com/consoleau/${project.name}/issues"
-        vcsUrl = "https://github.com/consoleau/${project.name}.git"
+nexusPublishing {
+    repositories {
+        sonatype {  //only for users registered in Sonatype after 24 Feb 2021
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
     }
 }


### PR DESCRIPTION
I've configured my Sonatype credentials in Settings -> Secrets.

After this is merged, I'll create a [new release](https://github.com/consoleau/kotlin-jpa-specification-dsl/releases) which should trigger the github action to publish ?